### PR TITLE
Fix pdf margins and content consistency

### DIFF
--- a/templates/deviation_statement.html
+++ b/templates/deviation_statement.html
@@ -11,16 +11,16 @@
 }
 
 .container {
-    width: 267mm; /* Expands to fit more of the page (297mm - 15mm left - 15mm right) */
-    min-height: 190mm;
-    margin: 20mm 15mm 10mm 15mm; /* Top: 20mm, Right: 15mm, Bottom: 10mm, Left: 15mm */
+    width: 277mm; /* 297mm - 10mm - 10mm for landscape A4 */
+    min-height: 187mm; /* 210mm - 10mm - 10mm */
+    margin: 10mm auto; 
     padding: 0;
     box-sizing: border-box;
 }
 
 table {
     width: 100%;
-    max-width: 267mm; /* Matches new container width */
+    max-width: 277mm; 
     border-collapse: collapse;
     table-layout: fixed;
 }
@@ -38,6 +38,11 @@ th, td {
     margin-bottom: 10px;
 }
 
+@page { size: A4 landscape; margin: 10mm; }
+@media print {
+  body { margin: 0; }
+  .container { margin: 10mm; width: 277mm; min-height: 187mm; }
+}
 
     </style>
 </head>

--- a/templates/extra_items.html
+++ b/templates/extra_items.html
@@ -5,10 +5,15 @@
     <title>Extra Items</title>
     <style>
         body { font-family: Calibri, sans-serif; font-size: 9pt; margin: 0; }
-        .container { width: 190mm; min-height: 287mm; margin: 10mm auto; padding: 10mm; box-sizing: border-box; }
-        table { width: 100%; border-collapse: collapse; }
+        .container { width: 190mm; min-height: 277mm; margin: 10mm auto; padding: 0; box-sizing: border-box; }
+        table { width: 100%; max-width: 190mm; border-collapse: collapse; }
         th, td { border: 1px solid black; padding: 5px; text-align: left; }
         .header { text-align: center; }
+        @page { size: A4 portrait; margin: 10mm; }
+        @media print {
+          body { margin: 0; }
+          .container { margin: 10mm; width: 190mm; min-height: 277mm; }
+        }
     </style>
 </head>
 <body>

--- a/templates/first_page.html
+++ b/templates/first_page.html
@@ -5,13 +5,18 @@
     <title>CONTRACTOR BILL</title>
     <style>
         body { font-family: Calibri, sans-serif; font-size: 9pt; margin: 0; }
-        .container { width: 180mm; min-height: 287mm; margin: 10mm 15mm; padding: 0; box-sizing: border-box; }
-        table { width: 100%; max-width: 180mm; border-collapse: collapse; table-layout: fixed; }
+        .container { width: 190mm; min-height: 277mm; margin: 10mm auto; padding: 0; box-sizing: border-box; }
+        table { width: 100%; max-width: 190mm; border-collapse: collapse; table-layout: fixed; }
         th, td { border: 1px solid black; padding: 5px; text-align: left; vertical-align: top; overflow: hidden; }
         .header { text-align: left; margin-bottom: 10px; }
         .header p { margin: 2px 0; }
         .bold { font-weight: bold; }
         .underline { text-decoration: underline; }
+        @page { size: A4 portrait; margin: 10mm; }
+        @media print {
+          body { margin: 0; }
+          .container { margin: 10mm; width: 190mm; min-height: 277mm; }
+        }
     </style>
 </head>
 <body>

--- a/templates/last_page.html
+++ b/templates/last_page.html
@@ -2,79 +2,30 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>First Page</title>
+    <title>Last Page Summary</title>
     <style>
-        body { font-family: Calibri, sans-serif; font-size: 9pt; margin: 0; }
-        .container { width: 210mm; min-height: 287mm; margin: 10mm 0; padding: 0; box-sizing: border-box; }
-        table { width: 100%; max-width: 210mm; border-collapse: collapse; table-layout: fixed; }
-        th, td { padding: 5px; text-align: left; vertical-align: top; overflow: hidden; }
-        .header { text-align: center; margin-bottom: 10px; }
-        th:nth-child(1) { width: 20mm; } /* Unit */
-        th:nth-child(2) { width: 20mm; } /* Quantity */
-        th:nth-child(3) { width: 20mm; } /* Serial No. */
-        th:nth-child(4) { width: 50mm; } /* Description */
-        th:nth-child(5) { width: 20mm; } /* Rate */
-        th:nth-child(6) { width: 20mm; } /* Amount */
-        th:nth-child(7) { width: 40mm; } /* Remark */
-        .divider { font-weight: bold; text-decoration: underline; }
+        body { font-family: Calibri, sans-serif; font-size: 11pt; margin: 0; }
+        .container { width: 190mm; min-height: 277mm; margin: 10mm auto; padding: 0; box-sizing: border-box; }
+        .header { text-align: center; margin-bottom: 15mm; }
+        .content { width: 100%; max-width: 190mm; }
+        .row { display: flex; justify-content: space-between; margin: 6mm 0; }
+        .label { font-weight: bold; }
+        @page { size: A4 portrait; margin: 10mm; }
+        @media print {
+          body { margin: 0; }
+          .container { margin: 10mm; width: 190mm; min-height: 277mm; }
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h2>Bill</h2>
-            <p>Agreement No: {{ data.header[0][1] if data.header and len(data.header) > 0 else 'N/A' }}</p>
+            <h2>Bill Summary</h2>
         </div>
-        <table>
-            <thead>
-                <tr>
-                    <th>Unit</th>
-                    <th>Quantity</th>
-                    <th>Serial No.</th>
-                    <th>Description</th>
-                    <th>Rate</th>
-                    <th>Amount</th>
-                    <th>Remark</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for item in data.items %}
-                    {% if item.is_divider %}
-                        <tr>
-                            <td colspan="7" class="divider">{{ item.description }}</td>
-                        </tr>
-                    {% else %}
-                        <tr>
-                            <td>{{ item.unit }}</td>
-                            <td>{{ item.quantity }}</td>
-                            <td>{{ item.serial_no }}</td>
-                            <td>{{ item.description }}</td>
-                            <td>{{ item.rate }}</td>
-                            <td>{{ item.amount }}</td>
-                            <td>{{ item.remark }}</td>
-                        </tr>
-                    {% endif %}
-                {% endfor %}
-                <tr>
-                    <td colspan="4"></td>
-                    <td>Grand Total</td>
-                    <td>{{ data.totals.grand_total }}</td>
-                    <td></td>
-                </tr>
-                <tr>
-                    <td colspan="4"></td>
-                    <td>Tender Premium @ {{ '%0.2f%%' | format(data.totals.premium.percent * 100) }}</td>
-                    <td>{{ data.totals.premium.amount }}</td>
-                    <td></td>
-                </tr>
-                <tr>
-                    <td colspan="4"></td>
-                    <td>Payable Amount</td>
-                    <td>{{ data.totals.payable }}</td>
-                    <td></td>
-                </tr>
-            </tbody>
-        </table>
+        <div class="content">
+            <div class="row"><div class="label">Payable Amount:</div><div>{{ data.payable_amount }}</div></div>
+            <div class="row"><div class="label">Total in Words:</div><div>{{ data.amount_words }}</div></div>
+        </div>
     </div>
 </body>
 </html>

--- a/templates/note_sheet.html
+++ b/templates/note_sheet.html
@@ -5,8 +5,8 @@
     <title>FINAL BILL SCRUTINY SHEET</title>
     <style>
         body { font-family: Calibri, sans-serif; font-size: 9pt; margin: 0; }
-        .container { width: 210mm; min-height: 287mm; margin: 10mm 0; padding: 0; box-sizing: border-box; }
-        table { width: 100%; max-width: 210mm; border-collapse: collapse; table-layout: fixed; }
+        .container { width: 190mm; min-height: 277mm; margin: 10mm auto; padding: 0; box-sizing: border-box; }
+        table { width: 100%; max-width: 190mm; border-collapse: collapse; table-layout: fixed; }
         th, td { padding: 5px; text-align: left; vertical-align: top; overflow: hidden; border: 1px solid black; }
         .header { text-align: center; margin-bottom: 10px; }
         .note-cell { white-space: pre-wrap; }
@@ -16,6 +16,11 @@
         .specific-table th:nth-child(1), .specific-table td:nth-child(1) { width: 10mm; }
         .specific-table th:nth-child(2), .specific-table td:nth-child(2) { width: 80mm; }
         .specific-table th:nth-child(3), .specific-table td:nth-child(3) { width: 90mm; }
+        @page { size: A4 portrait; margin: 10mm; }
+        @media print {
+          body { margin: 0; }
+          .container { margin: 10mm; width: 190mm; min-height: 277mm; }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Standardize PDF, DOCX, and HTML outputs to A4 with 10mm margins and ensure content consistency across all formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-105afe71-0c63-44ac-8454-fa03f920a4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-105afe71-0c63-44ac-8454-fa03f920a4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

